### PR TITLE
fix addon list not populating on linux

### DIFF
--- a/src/main/java/de/idrinth/waraddonclient/model/ActualAddon.java
+++ b/src/main/java/de/idrinth/waraddonclient/model/ActualAddon.java
@@ -339,10 +339,12 @@ public class ActualAddon implements de.idrinth.waraddonclient.model.Addon {
         url = "";
         hasSettings = false;
         File folder = find(name);
-        for (File fileEntry : folder.listFiles()) {
-            processFile(fileEntry);
-            if (hasSettings) {
-                return;
+        if (folder.exists()) {
+            for (File fileEntry : folder.listFiles()) {
+                processFile(fileEntry);
+                if (hasSettings) {
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #

Fix so that it works on linux.
EDIT: makes it so that it works if you dont have all addons regardless of OS

## Proposed Changes

  - check if folder exist before processing content
