### PR TITLE
Give more feedback on what exactly is the issue instead of just

### DIFF
--- a/src/main/java/de/idrinth/waraddonclient/BaseMain.java
+++ b/src/main/java/de/idrinth/waraddonclient/BaseMain.java
@@ -27,12 +27,20 @@ abstract class BaseMain {
     public void run() {
         try {
             Config config = new Config();
-            add(new FileLogger(config.getLogFile()));
+            getLog(config);
             Request client = new Request(new TrustManager(multiLogger), multiLogger, config);
             FileSystem file = new FileSystem(config);
             this.main(multiLogger, config, client, file);
         } catch (ParserConfigurationException|FileSystem.FileSystemException|IOException|CertificateException|KeyManagementException|KeyStoreException|NoSuchAlgorithmException|URISyntaxException ex) {
             multiLogger.error(ex);
+        }
+    }
+
+    public void getLog(Config cfg) throws IOException {
+        try {
+            add(new FileLogger(cfg.getLogFile()));
+        } catch (IOException ex) {
+            throw new IOException("Error with logging in " + cfg.getLogFile() + ": " + ex);
         }
     }
 }


### PR DESCRIPTION
"Permission deined" as an example

Fixes #
In the case of log file missing or not being able to write to it, before the client would just say Permission denied but it would not disclose for what file. I have added this for the log file (not sure if there are other files where this would be useful as well)

